### PR TITLE
check that device name matches k8s requirements

### DIFF
--- a/chi_edge/cli.py
+++ b/chi_edge/cli.py
@@ -31,7 +31,7 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from chi_edge import LOCAL_EGRESS, SUPPORTED_MACHINE_NAMES
+from chi_edge import LOCAL_EGRESS, SUPPORTED_MACHINE_NAMES, utils
 from chi_edge.image import find_boot_partition_id, read_config_json, write_config_json
 
 console = Console()
@@ -135,6 +135,9 @@ def register(
 
     """
     with doni_error_handler("failed to register device"):
+        if not utils.validate_rfc1123_name(device_name):
+            raise click.ClickException("device name must match RFC1123 DNS")
+
         device = (
             doni_client()
             .post(

--- a/chi_edge/utils.py
+++ b/chi_edge/utils.py
@@ -1,0 +1,21 @@
+import re
+
+
+def validate_rfc1123_name(name) -> bool:
+    """
+    Kubernetes enforces that node and container names are valid DNS subdomains.
+    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+    Specifically, the name must:
+    - contain no more than 253 characters
+    - contain only lowercase alphanumeric characters, '-' or '.'
+    - start with an alphanumeric character
+    - end with an alphanumeric character
+
+    Takes a string to check against the above requirements.
+    Returns true if the name complies with the above rules, and false otherwise.
+
+    """
+
+    rfc1123_dns_subdomain_regex_string = r"^[a-z0-9][a-z0-9-.]{0,253}[a-z0-9]$"
+    name_match = re.match(rfc1123_dns_subdomain_regex_string, name)
+    return bool(name_match)


### PR DESCRIPTION
k8s will fail to register a device if the name is too long, or contains invalid characters, such as an underscore `_`.
Validate names on device creation to prevent this error.