### PR TITLE
Feature Request: Adding ssh-keys while baking balena image

### DIFF
--- a/chi_edge/cli.py
+++ b/chi_edge/cli.py
@@ -385,6 +385,7 @@ def bake(device: "str", image: "str" = None, ssh_public_key: "str" = None):
     config["registryEndpoint"] = "registry2.balena-cloud.com"
     config["deltaEndpoint"] = "https://delta.balena-cloud.com"
 
+    # Add a public ssh key if specified
     if ssh_public_key:
         config["os"] = {"sshKeys" : [ssh_public_key]}
 

--- a/chi_edge/cli.py
+++ b/chi_edge/cli.py
@@ -300,7 +300,14 @@ def sync(device: "str"):
         "copied anywhere."
     ),
 )
-def bake(device: "str", image: "str" = None):
+@click.option(
+    "--ssh-public-key",
+    metavar="SSH PUBLIC KEY",
+    help=(
+        "A public ssh key as a string to be baked into the balena image."
+    ),
+)
+def bake(device: "str", image: "str" = None, ssh_public_key: "str" = None):
 
     config_file = Path("config.json")
     # Ensure we do not overwrite a `config.json` file on the user's system
@@ -377,6 +384,9 @@ def bake(device: "str", image: "str" = None):
     config["vpnEndpoint"] = "vpn.balena-cloud.com"
     config["registryEndpoint"] = "registry2.balena-cloud.com"
     config["deltaEndpoint"] = "https://delta.balena-cloud.com"
+
+    if ssh_public_key:
+        config["os"] = {"sshKeys" : [ssh_public_key]}
 
     # Put config data back into image
     with config_file.open("w") as f:


### PR DESCRIPTION
Hello!

I have been using chameleon as a part of the FOUNT project at University of Chicago (Argonne). I think it would be great if one could access the chi-edge device via ssh over the local network for development.

According to the balena docs it is possible to do this:
https://github.com/balena-os/meta-balena#sshkeys

I added an option to do this under the `bake` command in this PR.

Example:

`chi-edge device bake --image <image> --ssh-public-key <public ssh key> <device_uuid>`

I tested this on my end using a Raspberry Pi 4 registered with chi@edge on my home network.
